### PR TITLE
Improve getML Dockerfile: Fix docker build fail on WSL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN \
     else \
         export GETML_ARCH="${TARGETARCH}" ;\
     fi; \
-    export GETML_VERSION=$(grep -o "^getml==.*$" requirements.txt | cut -b8-) ;\
+    export GETML_VERSION=$(grep -oP '(?<=getml==)\d+\.\d+\.\d+' requirements.txt) ;\
     export GETML_BUCKET="https://storage.googleapis.com/static.getml.com/download" ;\
     export GETML_ENGINE_FILE="getml-${GETML_VERSION}-${GETML_ARCH}-${TARGETOS}.tar.gz" ;\
     export GETML_ENGINE_URL="${GETML_BUCKET}/${GETML_VERSION}/${GETML_ENGINE_FILE}" ;\


### PR DESCRIPTION
Updated the getML version extraction command to use a more precise regex pattern, ensuring accurate retrieval of the version number from `requirements.txt`. This change eliminates the risk of incorrect version parsing (e.g., due to newline characters on Windows/WSL) and removes the need for the `cut` command after `grep`.

Tested on Linux (Ubuntu) and Windows (WSL)